### PR TITLE
Changed max length of title suggestions

### DIFF
--- a/lib/models/suggestion.rb
+++ b/lib/models/suggestion.rb
@@ -9,7 +9,7 @@ class Suggestion
   include DataMapper::Resource
 
   property :id,         Serial
-  property :title,      String,   :length => 100,
+  property :title,      String,   :length => 40,
     :message => "That suggestion was too long. Showbot is sorry. Think title, not transcript."
   property :user,       String
   property :show,       String


### PR DESCRIPTION
New max length for the suggestions are set to 40 characters to filter out more of the trash. This is based off the max length of current show titles being 32, and the average of 23 characters.
