### PR TITLE
Separating titles for same show on consecutive days

### DIFF
--- a/lib/models/suggestion.rb
+++ b/lib/models/suggestion.rb
@@ -127,7 +127,7 @@ class Suggestion
       if suggestion_sets.empty? or last_show != suggestion.show or (last_time - suggestion.created_at) > split_interval
         suggestion_sets << SuggestionSet.new(suggestion.show)
       end
-	    
+
       last_show = suggestion.show
       last_time = suggestion.created_at
 


### PR DESCRIPTION
When a show (usually The Frequency) airs twice in a row without any shows in between, the titles submitted for the second day are co-mingled with those from the first.

I just modified the `group_by_show` class method of `Suggestion` to also split up titles (i.e. create a new `SuggestionSet`) if there is more than 18 hours between title suggestions for the same show.
