### PR TITLE
Adds OAuth to the twitter broadcast plugin.

### DIFF
--- a/lib/cinch/plugins/twitter_broadcast.rb
+++ b/lib/cinch/plugins/twitter_broadcast.rb
@@ -10,6 +10,14 @@ module Cinch
   module Plugins
     class TwitterBroadcast
       include Cinch::Plugin
+      
+      Twitter.configure do |config|
+        config.consumer_key = YOUR_CONSUMER_KEY
+        config.consumer_secret = YOUR_CONSUMER_SECRET
+        config.oauth_token = YOUR_OAUTH_TOKEN
+        config.oauth_token_secret = YOUR_OAUTH_TOKEN_SECRET
+      end
+
 
       timer 60, :method => :send_last_status
       


### PR DESCRIPTION
This commit adds OAuth to the twitter broadcast plugin to work with the twitter API v1.1.

Explanation:
I noticed i started getting errors related to twitter in the server log basically boiling down to:

> ~/.rvm/gems/ruby-1.9.2-p320/gems/twitter-4.5.0/lib/twitter/response/raise_error.rb:21:in `on_complete': Bad Authentication data (Twitter::Error::BadRequest)

After some poking around, i believe this may be due to twitter [phasing out the 1.0 API very soon](https://dev.twitter.com/blog/api-v1-retirement-final-dates)?

The simple and quick fix i found for this was to follow the instructions over on the [twitter gem site](http://sferik.github.io/twitter/) and add to twitter_broadcast.rb

``` ruby
Twitter.configure do |config|
  config.consumer_key = YOUR_CONSUMER_KEY
  config.consumer_secret = YOUR_CONSUMER_SECRET
  config.oauth_token = YOUR_OAUTH_TOKEN
  config.oauth_token_secret = YOUR_OAUTH_TOKEN_SECRET
end
```

as shown in commit c97715f9c4307fe037771a8a13c86f45bb9fa9b4 and then [registering the application with a twitter account](https://dev.twitter.com/apps/new) and plugging things in the the proper locations.

This fix seems to work in my very limited testing.

There may be easier/cleaner ways to do this, but this seems to be the most straightforward way of doing it with the current code structure and with the 1.0 API cutoff looming, I figured i'd push the quick fix upstream. ;)

This config stuff is probably something that should be considered as part of issue #31 later on, so i'll reference it here so it's not forgotten. :)
